### PR TITLE
fix wrong macro is being used for linux platform

### DIFF
--- a/src/sys.h
+++ b/src/sys.h
@@ -9,7 +9,7 @@
 typedef HANDLE file_handle_t;
 #endif
 
-#ifdef ZAKO_TARGET_POSIX
+#ifdef ZAKO_TARGET_LINUX
 typedef int file_handle_t;
 #endif
 


### PR DESCRIPTION
In commit 0e471dfb, the macro `ZAKO_TARGET_POSIX` has been changed to `ZAKO_TARGET_LINUX` to distinguish between macOS and Linux-based systems. However, `sys.h` did not change macro uses accordingly, causing missing definitions during Linux builds. This Pull-Request fixes this issue by changing `ZAKO_TARGET_POSIX` in `sys.h` to `ZAKO_TARGET_LINUX`. 