### PR TITLE
Extended sys interface for Windows Support

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -184,7 +184,7 @@ ZakoCommandHandler(root_sign) {
         target = zako_sys_file_opencopy(input, output, overwrite);
     }
 
-    if (target == -1) {
+    if (!zako_sys_is_file_valid(target)) {
         exit(1);
     }
     
@@ -200,14 +200,14 @@ ZakoCommandHandler(root_sign) {
     }
     size_t target_sz = zako_sys_file_sz(target);
 
-    ConsoleWriteOK("File Signature created: %s (%lu bytes digested)", base64_encode(result, ZAKO_SIGNATURE_LENGTH, NULL), target_sz);
+    ConsoleWriteOK("File Signature created: %s (%zu bytes digested)", base64_encode(result, ZAKO_SIGNATURE_LENGTH, NULL), target_sz);
     
     zako_esign_set_signature(es_ctx, hash, result);
     
     size_t len = 0;
     struct zako_esignature* esig = zako_esign_create(es_ctx, &len);
 
-    ConsoleWriteOK("Writing E-Signature info (%lu bytes)...", len);
+    ConsoleWriteOK("Writing E-Signature info (%zu bytes)...", len);
     if (!zako_file_write_esig(target, esig, len)) {
         exit(1);
     }
@@ -349,10 +349,11 @@ ZakoCommandHandler(root_info) {
 
 no_cert:;
     
-    struct tm* timeinfo = gmtime((const time_t*) &esig->created_at);
+    struct tm timeinfo;
     char time_buffer[32];
-    if (timeinfo) {
-        strftime(time_buffer, 32, "%Y-%m-%dT%H:%M:%SZ", timeinfo);
+
+    if (zako_sys_gmtime_s((const time_t*) &esig->created_at, &timeinfo)) {
+        strftime(time_buffer, 32, "%Y-%m-%dT%H:%M:%SZ", &timeinfo);
         ConsoleWriteOK("  Signed At: %s", time_buffer);
     } else {
         ConsoleWriteOK("  Signed At: <Unknown>");
@@ -464,7 +465,7 @@ static char* zako_cli_prompt(const char* prompt) {
     char* line = NULL;
     size_t n = 0;
 
-    ssize_t len = getline(&line, &n, stdin);
+    ssize_t len = zako_sys_getline(&line, &n, stdin);
     if (len < 0) {
         free(line);
         return NULL;

--- a/src/esignature/file_helper.c
+++ b/src/esignature/file_helper.c
@@ -1,8 +1,6 @@
 #include "file_helper.h"
 
 #include <openssl/err.h>
-#include <sys/mman.h>
-#include <sys/syscall.h>
 
 #include "ed25519_sign.h"
 

--- a/src/esignature/file_helper.c
+++ b/src/esignature/file_helper.c
@@ -28,10 +28,6 @@ bool zako_file_sign(file_handle_t fd, EVP_PKEY* key, uint8_t* result, uint8_t* h
 }
 
 bool zako_file_write_esig(file_handle_t fd, struct zako_esignature* esignature, size_t len) {
-    if (lseek(fd, 0, SEEK_END) == -1) {
-        return false;
-    }
-
     uint64_t magic = ZAKO_ESIGNATURE_MAGIC;
 
     zako_sys_file_append_end(fd, (uint8_t*) esignature, len);

--- a/src/esignature/file_helper.h
+++ b/src/esignature/file_helper.h
@@ -6,10 +6,6 @@
 #include "esignature.h"
 
 #include <openssl/evp.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 
 #define ZAKO_FV_MMAP_FAILED    (1 << 16)
 #define ZAKO_FV_INVALID_HEADER (1 << 17)

--- a/src/prelude.h
+++ b/src/prelude.h
@@ -21,7 +21,19 @@
 #undef ZAKO_TARGET_LINUX
 #endif
 
+#define uint64_t HACK_USE_ONLY
 #include <stdint.h>
+#undef uint64_t
+
+/**
+ * The reason why we hacked uint64_t is because
+ * the definition of uint64_t is not consistant across different os.
+ * On macOS x64, uint64_t = ull
+ * On Linux x64, uint64_t = uli
+ * Although they have the same size (64b), but we have to use different formats in printf (%llu vs %lu).
+ */
+typedef unsigned long long uint64_t;
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/src/sys.h
+++ b/src/sys.h
@@ -2,11 +2,14 @@
 #define ZAKOSIGN_HEADER_SYS_H
 
 #include "prelude.h"
+#include <time.h>
 
 #ifdef ZAKO_TARGET_NT
-#include <winbase.h>
+#include <BaseTsd.h>
 
-typedef HANDLE file_handle_t;
+typedef void* file_handle_t;
+typedef SSIZE_T ssize_t;
+#define ZAKO_FHAND_ERROR 0
 #endif
 
 #ifdef ZAKO_TARGET_POSIX
@@ -67,5 +70,19 @@ void* zako_sys_file_map_rw(file_handle_t file, size_t sz);
  */
 void zako_sys_file_unmap(void* ptr, size_t sz);  
 
+/**
+ * Read one line (until \n) from FILE*
+ */
+ssize_t zako_sys_getline(char** lineptr, size_t* n, FILE* stream);
+
+/**
+ * Safe version of gmtime
+ */
+bool zako_sys_gmtime_s(const time_t* timer, struct tm* buf);
+
+/**
+ * Checks if the given file handle is valid or not
+ */
+bool zako_sys_is_file_valid(file_handle_t file);
 
 #endif

--- a/src/sys.h
+++ b/src/sys.h
@@ -2,7 +2,6 @@
 #define ZAKOSIGN_HEADER_SYS_H
 
 #include "prelude.h"
-#include <time.h>
 
 #ifdef ZAKO_TARGET_NT
 #include <BaseTsd.h>
@@ -13,12 +12,24 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #ifdef ZAKO_TARGET_POSIX
+
+#ifdef __STDC_LIB_EXT1__
+#define __STDC_WANT_LIB_EXT1__
+#endif
+
 typedef int file_handle_t;
 #endif
 
 #ifdef ZAKO_TARGET_APPLE
+
+#ifdef __STDC_LIB_EXT1__
+#define __STDC_WANT_LIB_EXT1__
+#endif
+
 typedef int file_handle_t;
 #endif
+
+#include <time.h>
 
 /**
  * Check if given path exist and can be accessed

--- a/src/sys_linux.c
+++ b/src/sys_linux.c
@@ -121,4 +121,16 @@ void zako_sys_file_unmap(void* ptr, size_t sz) {
     munmap(ptr, sz);
 }
 
+ssize_t zako_sys_getline(char** lineptr, size_t* n, FILE* stream) {
+    return getline(lineptr, n, stream);
+}
+
+bool zako_sys_gmtime_s(const time_t* timer, struct tm* buf) {
+    return gmtime_s(timer, buf) != NULL;
+}
+
+bool zako_sys_is_file_valid(file_handle_t file) {
+    return file != -1;
+}
+
 #endif

--- a/src/sys_linux.c
+++ b/src/sys_linux.c
@@ -88,6 +88,10 @@ file_handle_t zako_sys_file_opencopy(char* path, char* new, bool overwrite) {
 }
 
 void zako_sys_file_append_end(file_handle_t file, uint8_t* data, size_t sz) {
+    if (lseek(file, 0, SEEK_END) == -1) {
+        return;
+    }
+
     write(file, (void*) data, sz);
 }
 

--- a/src/sys_linux.c
+++ b/src/sys_linux.c
@@ -126,7 +126,11 @@ ssize_t zako_sys_getline(char** lineptr, size_t* n, FILE* stream) {
 }
 
 bool zako_sys_gmtime_s(const time_t* timer, struct tm* buf) {
+#ifdef __STDC_LIB_EXT1__
     return gmtime_s(timer, buf) != NULL;
+#else
+    return gmtime_r(timer, buf) != NULL;
+#endif
 }
 
 bool zako_sys_is_file_valid(file_handle_t file) {

--- a/src/sys_nt.c
+++ b/src/sys_nt.c
@@ -1,0 +1,167 @@
+#include "sys.h"
+
+#if ZAKO_TARGET_NT
+#include <Windows.h>
+#include <Shlwapi.h>
+#include <fileapi.h>
+#include <winbase.h>
+
+bool zako_sys_file_exist(char* path) {
+    return PathFileExistsA(path);
+}
+
+file_handle_t zako_sys_file_open(char* path) {
+    HANDLE handle = CreateFileA(path, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_APPEND_DATA, NULL);
+    if (GetLastError() == ERROR_FILE_NOT_FOUND) {
+        ConsoleWriteFAIL("Failed to open %s because file does not exist!", path);
+    }
+
+    return handle;
+}
+
+file_handle_t zako_sys_file_opencopy(char* path, char* new, bool overwrite) {
+    if (!CopyFileA(path, new, !overwrite)) {
+        ConsoleWriteFAIL("Failed to open a copy of %s at %s", path, new);
+
+        return NULL;
+    }
+
+    return zako_sys_file_open(new);
+}
+
+void zako_sys_file_append_end(file_handle_t file, uint8_t* data, size_t sz) {
+    WriteFile(file, data, sz, 0, NULL);
+}
+
+void zako_sys_file_close(file_handle_t file) {
+    CloseHandle(file);
+}
+
+size_t zako_sys_file_sz(file_handle_t file) {
+    LARGE_INTEGER li;
+    GetFileSizeEx(file, &li);
+
+    if (li.HighPart != 0) {
+        ConsoleWriteFAIL("Error: File too big");
+        return 0;
+    }
+
+    return li.LowPart;
+}
+
+size_t zako_sys_file_szatpath(char* path) {
+    WIN32_FILE_ATTRIBUTE_DATA data;
+    GetFileAttributesExA(path, GetFileExInfoStandard, &data);
+
+    if (data.nFileSizeHigh != 0) {
+        ConsoleWriteFAIL("Error: File %s is too big", path);
+        return 0;
+    } 
+
+    return data.nFileSizeLow;
+}
+
+void* zako_sys_file_map(file_handle_t file, size_t sz) {
+    HANDLE hMapFile = CreateFileMappingA(file, NULL, PAGE_READONLY, 0, 0, NULL);
+    return MapViewOfFile(hMapFile, FILE_MAP_READ, 0, 0, 0);
+}
+
+void* zako_sys_file_map_rw(file_handle_t file, size_t sz) {
+    HANDLE hMapFile = CreateFileMappingA(file, NULL, PAGE_READWRITE, 0, 0, NULL);
+    return MapViewOfFile(hMapFile, FILE_MAP_WRITE, 0, 0, 0);
+}
+
+void zako_sys_file_unmap(void* ptr, size_t sz) {
+    UnmapViewOfFile(ptr);
+
+    /* lets leak this for convenient purpose  
+    CloseHandle(); */
+}
+
+/* https://stackoverflow.com/questions/735126/are-there-alternate-implementations-of-gnu-getline-interface
+   Visited at Nov. 24, 2025
+*/
+/* The original code is public domain -- Will Hartung 4/9/2009 */
+/* Modifications, public domain as well, by Antti Haapala, 11/10/2017
+   - Switched to getc on 5/23/2019
+   - Proper error handling on IO error and wraparound 
+     check on buffer extension 3/31/2025 - 4/2/2025
+*/
+#define MINIMUM_BUFFER_SIZE 128
+ssize_t zako_sys_getline(char **lineptr, size_t *n, FILE *stream) {
+    size_t pos;
+    int c;
+
+    if (lineptr == NULL || stream == NULL || n == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    c = getc(stream);
+    if (c == EOF) {
+        return -1;
+    }
+
+    if (*lineptr == NULL) {
+        *lineptr = malloc(MINIMUM_BUFFER_SIZE);
+        if (*lineptr == NULL) {
+            return -1;
+        }
+        *n = MINIMUM_BUFFER_SIZE;
+    }
+
+    pos = 0;
+    while(c != EOF) {
+        if (pos + 1 >= *n) {
+            size_t new_size = *n + (*n >> 2);
+
+            // have some reasonable minimum
+            if (new_size < MINIMUM_BUFFER_SIZE) {
+                new_size = MINIMUM_BUFFER_SIZE;
+            }
+            
+            // size_t wraparound
+            if (new_size <= *n) {
+                errno = ENOMEM;
+                return -1;
+            }
+
+            // Note you might also want to check that PTRDIFF_MAX
+            // is not exceeded!
+
+            char *new_ptr = realloc(*lineptr, new_size);
+            if (new_ptr == NULL) {
+                return -1;
+            }
+            *n = new_size;
+            *lineptr = new_ptr;
+        }
+
+        ((unsigned char *)(*lineptr))[pos ++] = c;
+        if (c == '\n') {
+            break;
+        }
+        c = getc(stream);
+    }
+
+    (*lineptr)[pos] = '\0';
+    
+    // if an IO error occurred, return -1
+    if (c == EOF && !feof(stream)) {
+        return -1;
+    }
+
+    // otherwise we successfully read until the end-of-file
+    // or the delimiter
+    return pos;
+}
+
+bool zako_sys_gmtime_s(const time_t* timer, struct tm* buf) {
+    return gmtime_s(buf, timer) != EINVAL;
+}
+
+bool zako_sys_is_file_valid(file_handle_t file) {
+    return file != NULL;
+}
+
+#endif

--- a/src/sys_osx.c
+++ b/src/sys_osx.c
@@ -87,4 +87,16 @@ void zako_sys_file_unmap(void* ptr, size_t sz) {
     munmap(ptr, sz);
 }
 
+ssize_t zako_sys_getline(char** lineptr, size_t* n, FILE* stream) {
+    return getline(lineptr, n, stream);
+}
+
+bool zako_sys_gmtime_s(const time_t* timer, struct tm* buf) {
+    return gmtime_s(timer, buf) != NULL;
+}
+
+bool zako_sys_is_file_valid(file_handle_t file) {
+    return file != -1;
+}
+
 #endif

--- a/src/sys_osx.c
+++ b/src/sys_osx.c
@@ -92,7 +92,11 @@ ssize_t zako_sys_getline(char** lineptr, size_t* n, FILE* stream) {
 }
 
 bool zako_sys_gmtime_s(const time_t* timer, struct tm* buf) {
+#ifdef __STDC_LIB_EXT1__
     return gmtime_s(timer, buf) != NULL;
+#else
+    return gmtime_r(timer, buf) != NULL;
+#endif
 }
 
 bool zako_sys_is_file_valid(file_handle_t file) {

--- a/src/sys_osx.c
+++ b/src/sys_osx.c
@@ -54,6 +54,10 @@ file_handle_t zako_sys_file_opencopy(char* path, char* new, bool overwrite) {
 }
 
 void zako_sys_file_append_end(file_handle_t file, uint8_t* data, size_t sz) {
+    if (lseek(file, 0, SEEK_END) == -1) {
+        return;
+    }
+
     write(file, (void*) data, sz);
 }
 


### PR DESCRIPTION
This pull request added more functions (`zako_sys_getline`, `zako_sys_is_file_valid` and `zako_sys_gmtime_s`) to the current sys interface. This is mandatory for Windows native support.

`zako_sys_gmtime_s` is a wrapper for `gmtime_s`, which has different definitions across Windows and Linux.

`zako_sys_is_file_valid` is a function that tests whether a given file handle (or file descriptor) is valid. On Windows, NULL represents invalid; on Linux, -1 represents invalid.

`zako_sys_getline` is not implemented on Windows, so we added it back.

This PR also added `ssize_t`, which is also missing on Windows.
